### PR TITLE
gl: remove extra program->Init() call

### DIFF
--- a/common/compositor/gl/glrenderer.cpp
+++ b/common/compositor/gl/glrenderer.cpp
@@ -130,7 +130,6 @@ GLProgram *GLRenderer::GetProgram(unsigned texture_count) {
   }
 
   std::unique_ptr<GLProgram> program(new GLProgram());
-  program->Init(texture_count);
   if (program->Init(texture_count)) {
     if (programs_.size() < texture_count)
       programs_.resize(texture_count);


### PR DESCRIPTION
No sense in calling Init twice as it should always give the same result.
Drop the unused call.

Signed-off-by: Kevin Strasser <kevin.strasser@intel.com>