### PR TITLE
Test: fence logic change; Since each frame are single buffered, it sh…

### DIFF
--- a/tests/apps/jsonlayerstest.cpp
+++ b/tests/apps/jsonlayerstest.cpp
@@ -131,7 +131,8 @@ bool init_gl() {
   return true;
 }
 
-static struct frame frames[2];
+// frames count should be larger than 3 for performance
+static struct frame frames[4];
 
 class HotPlugEventCallback : public hwcomposer::DisplayHotPlugEventCallback {
  public:
@@ -341,6 +342,7 @@ static void fill_hwclayer(hwcomposer::HwcLayer *pHwcLayer,
       pParameter->frame_x, pParameter->frame_y, pParameter->frame_width,
       pParameter->frame_height));
   pHwcLayer->SetNativeHandle(pRenderer->GetNativeBoHandle());
+  pHwcLayer->release_fence.Reset(-1);
 }
 
 static void init_frames(int32_t width, int32_t height) {
@@ -496,12 +498,13 @@ int main(int argc, char *argv[]) {
 
   for (uint64_t i = 0; arg_frames == 0 || i < arg_frames; ++i) {
     struct frame *frame = &frames[i % ARRAY_SIZE(frames)];
+    struct frame *frame_next = &frames[(i + 1) % ARRAY_SIZE(frames)];
 
-    for (uint32_t j = 0; j < frame->layers.size(); j++) {
-      if (frame->layers[j]->release_fence.get() != -1) {
-        ret = sync_wait(frame->layers[j]->release_fence.get(), 1000);
+    for (uint32_t j = 0; j < frame_next->layers.size(); j++) {
+      if (frame_next->layers[j]->release_fence.get() != -1) {
+        ret = sync_wait(frame_next->layers[j]->release_fence.get(), 1000);
         if (ret) {
-          frame->layers[j]->release_fence.Reset(-1);
+          frame_next->layers[j]->release_fence.Reset(-1);
         }
       }
     }

--- a/tests/common/gllayerrenderer.h
+++ b/tests/common/gllayerrenderer.h
@@ -33,9 +33,11 @@ class GLLayerRenderer : public LayerRenderer {
   virtual void glDrawFrame() = 0;
 
  protected:
+  bool Init_GL(glContext* gl);
   GLuint gl_renderbuffer_;
   GLuint gl_framebuffer_;
   EGLImageKHR egl_image_;
+  glContext* gl_ = NULL;
 };
 
 #endif

--- a/tests/common/layerrenderer.cpp
+++ b/tests/common/layerrenderer.cpp
@@ -18,13 +18,11 @@
 
 LayerRenderer::LayerRenderer(struct gbm_device* dev) {
   gbm_dev_ = dev;
-  gl_ = NULL;
 }
 
 LayerRenderer::~LayerRenderer() {
   if (gbm_bo_)
     gbm_bo_destroy(gbm_bo_);
-
   gbm_bo_ = NULL;
 }
 
@@ -55,7 +53,5 @@ bool LayerRenderer::Init(uint32_t width, uint32_t height, uint32_t format,
   native_handle_.import_data.format = gbm_bo_get_format(gbm_bo_);
   format_ = format;
 
-  if (gl)
-    gl_ = gl;
   return true;
 }

--- a/tests/common/layerrenderer.h
+++ b/tests/common/layerrenderer.h
@@ -55,7 +55,6 @@ class LayerRenderer {
   struct gbm_handle native_handle_;
   struct gbm_device* gbm_dev_;
   uint32_t format_;
-  glContext* gl_;
 };
 
 #endif


### PR DESCRIPTION
…ould wait for the next frame's fence to be signaled, that is the display are displaying the new frame, then it could continue to draw it buffer;
Separate gl Context of different glRenderers