### PR TITLE
Test: different renders should use different GL context to avoid comm…

### DIFF
--- a/tests/common/gllayerrenderer.cpp
+++ b/tests/common/gllayerrenderer.cpp
@@ -24,6 +24,45 @@ GLLayerRenderer::GLLayerRenderer(struct gbm_device* dev) : LayerRenderer(dev) {
 }
 
 GLLayerRenderer::~GLLayerRenderer() {
+  if (gl_)
+    delete gl_;
+  gl_ = NULL;
+}
+
+bool GLLayerRenderer::Init_GL(glContext* gl) {
+  EGLint n;
+  static const EGLint context_attribs[] = {EGL_CONTEXT_CLIENT_VERSION, 3,
+                                           EGL_NONE};
+
+  static const EGLint config_attribs[] = {EGL_SURFACE_TYPE, EGL_DONT_CARE,
+                                          EGL_NONE};
+
+  gl_ = new glContext;
+  gl_->display = gl->display;
+  gl_->glEGLImageTargetRenderbufferStorageOES =
+      gl->glEGLImageTargetRenderbufferStorageOES;
+  gl_->eglCreateImageKHR = gl->eglCreateImageKHR;
+  gl_->eglCreateSyncKHR = gl->eglCreateSyncKHR;
+  gl_->eglDestroySyncKHR = gl->eglDestroySyncKHR;
+  gl_->eglWaitSyncKHR = gl->eglWaitSyncKHR;
+  gl_->eglClientWaitSyncKHR = gl->eglClientWaitSyncKHR;
+  gl_->eglDupNativeFenceFDANDROID = gl->eglDupNativeFenceFDANDROID;
+  gl_->glEGLImageTargetTexture2DOES = gl->glEGLImageTargetTexture2DOES;
+  gl_->eglDestroyImageKHR = gl->eglDestroyImageKHR;
+
+  if (!eglChooseConfig(gl_->display, config_attribs, &gl_->config, 1, &n) ||
+      n != 1) {
+    printf("failed to choose config: %d\n", n);
+    return false;
+  }
+  gl_->context = eglCreateContext(gl_->display, gl_->config, EGL_NO_CONTEXT,
+                                  context_attribs);
+
+  if (gl_->context == NULL) {
+    printf("failed to create context\n");
+    return false;
+  }
+  return true;
 }
 
 bool GLLayerRenderer::Init(uint32_t width, uint32_t height, uint32_t format,
@@ -32,6 +71,10 @@ bool GLLayerRenderer::Init(uint32_t width, uint32_t height, uint32_t format,
     return false;
   if (!LayerRenderer::Init(width, height, format, gl))
     return false;
+
+  if (!Init_GL(gl)) {
+    ETRACE("Failed to create gl context for layer renderer");
+  }
 
   eglMakeCurrent(gl_->display, EGL_NO_SURFACE, EGL_NO_SURFACE, gl_->context);
 

--- a/tests/common/gllayerrenderer.h
+++ b/tests/common/gllayerrenderer.h
@@ -33,9 +33,11 @@ class GLLayerRenderer : public LayerRenderer {
   virtual void glDrawFrame() = 0;
 
  protected:
+  bool Init_GL(glContext* gl);
   GLuint gl_renderbuffer_;
   GLuint gl_framebuffer_;
   EGLImageKHR egl_image_;
+  glContext* gl_ = NULL;
 };
 
 #endif

--- a/tests/common/layerrenderer.cpp
+++ b/tests/common/layerrenderer.cpp
@@ -18,13 +18,11 @@
 
 LayerRenderer::LayerRenderer(struct gbm_device* dev) {
   gbm_dev_ = dev;
-  gl_ = NULL;
 }
 
 LayerRenderer::~LayerRenderer() {
   if (gbm_bo_)
     gbm_bo_destroy(gbm_bo_);
-
   gbm_bo_ = NULL;
 }
 
@@ -55,7 +53,5 @@ bool LayerRenderer::Init(uint32_t width, uint32_t height, uint32_t format,
   native_handle_.import_data.format = gbm_bo_get_format(gbm_bo_);
   format_ = format;
 
-  if (gl)
-    gl_ = gl;
   return true;
 }

--- a/tests/common/layerrenderer.h
+++ b/tests/common/layerrenderer.h
@@ -57,7 +57,6 @@ class LayerRenderer {
   struct gbm_handle native_handle_;
   struct gbm_device* gbm_dev_;
   uint32_t format_;
-  glContext* gl_;
 };
 
 #endif


### PR DESCRIPTION
…and context conflicts. Also it could enable the renderers to run in different threads