### PR TITLE
Add support to use either of GBM or Mini GBM as needed

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -27,8 +27,12 @@ SUBDIRS = \
 MAINTAINERCLEANFILES = ChangeLog INSTALL
 
 AM_CPP_INCLUDES = -I$(top_srcdir) -Ipublic -Icommon/core -Icommon/utils -Icommon/compositor -Icommon/display  -Ios/linux -Icommon/compositor/gl -Itests/common
-AM_CPPFLAGS = -std=c++11 -DUDEV_SUPPORT -DUSE_MINIGBM -fPIC -O2 -D_FORTIFY_SOURCE=2 -fstack-protector-strong -fPIE
+AM_CPPFLAGS = -std=c++11 -DUDEV_SUPPORT -fPIC -O2 -D_FORTIFY_SOURCE=2 -fstack-protector-strong -fPIE
 AM_CPPFLAGS += $(AM_CPP_INCLUDES) $(CWARNFLAGS) $(DRM_CFLAGS) $(DEBUG_CFLAGS) -Wformat -Wformat-security
+
+if !ENABLE_GBM
+AM_CPPFLAGS += -DUSE_MINIGBM
+endif
 
 libhwcomposer_la_LIBADD = \
 	$(DRM_LIBS) \

--- a/configure.ac
+++ b/configure.ac
@@ -69,6 +69,22 @@ else
   AC_MSG_RESULT([RDRAND Hardware RNG Hash Seed disabled. Use --enable-rdrand to enable])
 fi
 
+AC_ARG_ENABLE(gbm,
+  AS_HELP_STRING([--enable-gbm],
+    [Enable GBM buffer manager.]),
+[if test x$enableval = xyes; then
+  enable_gbm=yes
+  AC_DEFINE(ENABLE_GBM, 1, [Enable GBM buffer manager])
+fi])
+
+AM_CONDITIONAL(ENABLE_GBM, test x$enable_gbm = xyes)
+
+if test "x$enable_gbm" = "xyes"; then
+  AC_MSG_RESULT([GBM buffer manager enabled on supported x86/x64 platforms])
+else
+  AC_MSG_RESULT([Mini GBM buffer manager is enabled. Use --enable-gbm to disable])
+fi
+
 AM_PROG_CC_C_O
 AC_PROG_CC_C99
 

--- a/os/linux/gbmutils.h
+++ b/os/linux/gbmutils.h
@@ -1,0 +1,81 @@
+/*
+// Copyright (c) 2017 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+*/
+
+#ifndef OS_LINUX_GBMUTILS_H_
+#define OS_LINUX_GBMUTILS_H_
+
+#include <drm_fourcc.h>
+static size_t gbm_bo_get_num_planes(uint32_t format) {
+  switch (format) {
+    case DRM_FORMAT_ABGR1555:
+    case DRM_FORMAT_ABGR2101010:
+    case DRM_FORMAT_ABGR4444:
+    case DRM_FORMAT_ABGR8888:
+    case DRM_FORMAT_ARGB1555:
+    case DRM_FORMAT_ARGB2101010:
+    case DRM_FORMAT_ARGB4444:
+    case DRM_FORMAT_ARGB8888:
+    case DRM_FORMAT_AYUV:
+    case DRM_FORMAT_BGR233:
+    case DRM_FORMAT_BGR565:
+    case DRM_FORMAT_BGR888:
+    case DRM_FORMAT_BGRA1010102:
+    case DRM_FORMAT_BGRA4444:
+    case DRM_FORMAT_BGRA5551:
+    case DRM_FORMAT_BGRA8888:
+    case DRM_FORMAT_BGRX1010102:
+    case DRM_FORMAT_BGRX4444:
+    case DRM_FORMAT_BGRX5551:
+    case DRM_FORMAT_BGRX8888:
+    case DRM_FORMAT_C8:
+    case DRM_FORMAT_GR88:
+    case DRM_FORMAT_R8:
+    case DRM_FORMAT_RG88:
+    case DRM_FORMAT_RGB332:
+    case DRM_FORMAT_RGB565:
+    case DRM_FORMAT_RGB888:
+    case DRM_FORMAT_RGBA1010102:
+    case DRM_FORMAT_RGBA4444:
+    case DRM_FORMAT_RGBA5551:
+    case DRM_FORMAT_RGBA8888:
+    case DRM_FORMAT_RGBX1010102:
+    case DRM_FORMAT_RGBX4444:
+    case DRM_FORMAT_RGBX5551:
+    case DRM_FORMAT_RGBX8888:
+    case DRM_FORMAT_UYVY:
+    case DRM_FORMAT_VYUY:
+    case DRM_FORMAT_XBGR1555:
+    case DRM_FORMAT_XBGR2101010:
+    case DRM_FORMAT_XBGR4444:
+    case DRM_FORMAT_XBGR8888:
+    case DRM_FORMAT_XRGB1555:
+    case DRM_FORMAT_XRGB2101010:
+    case DRM_FORMAT_XRGB4444:
+    case DRM_FORMAT_XRGB8888:
+    case DRM_FORMAT_YUYV:
+    case DRM_FORMAT_YVYU:
+      return 1;
+    case DRM_FORMAT_NV12:
+      return 2;
+    case DRM_FORMAT_YVU420:
+      return 3;
+  }
+
+  fprintf(stderr, "GBM: UNKNOWN FORMAT %d\n", format);
+  return 0;
+}
+
+#endif  // OS_LINUX_GBMUTILS_H_

--- a/os/linux/platformdefines.h
+++ b/os/linux/platformdefines.h
@@ -28,7 +28,11 @@
 #include <libsync.h>
 
 struct gbm_handle {
+#ifdef USE_MINIGBM
   struct gbm_import_fd_planar_data import_data;
+#else
+  struct gbm_import_fd_data import_data;
+#endif
   struct gbm_bo* bo = NULL;
 };
 

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -27,8 +27,12 @@ testlayers_LDFLAGS = \
 	-no-undefined
 
 AM_CPP_INCLUDES = -I$(top_srcdir) -I$(top_srcdir)/public -I../common/core -I../common/utils -I../common/compositor -I../common/display  -I../os/linux -I./common -I./third_party/json-c
-AM_CPPFLAGS = -std=c++11 -DUSE_MINIGBM -fPIC -O2 -D_FORTIFY_SOURCE=2 -fstack-protector-strong -fPIE
+AM_CPPFLAGS = -std=c++11 -fPIC -O2 -D_FORTIFY_SOURCE=2 -fstack-protector-strong -fPIE
 AM_CPPFLAGS += $(AM_CPP_INCLUDES) $(CWARNFLAGS) $(DRM_CFLAGS) $(DEBUG_CFLAGS) -Wformat -Wformat-security
+
+if !ENABLE_GBM
+AM_CPPFLAGS += -DUSE_MINIGBM
+endif
 
 testlayers_LDADD = \
 	$(DRM_LIBS) \
@@ -50,8 +54,12 @@ testlayers_SOURCES = \
     ./common/layerrenderer.cpp \
     ./common/gllayerrenderer.cpp \
     ./common/glcubelayerrenderer.cpp \
-    ./common/videolayerrenderer.cpp \
-    ./common/imagelayerrenderer.cpp \
     ./common/esTransform.cpp \
     ./common/layerfromjson.cpp \
     ./apps/jsonlayerstest.cpp
+
+if !ENABLE_GBM
+testlayers_SOURCES +=	\
+    ./common/videolayerrenderer.cpp \
+    ./common/imagelayerrenderer.cpp
+endif

--- a/tests/apps/jsonlayerstest.cpp
+++ b/tests/apps/jsonlayerstest.cpp
@@ -396,6 +396,7 @@ static void init_frames(int32_t width, int32_t height) {
         case LAYER_TYPE_GL:
           renderer = new GLCubeLayerRenderer(gbm.dev, false);
           break;
+#ifdef USE_MINIGBM
         case LAYER_TYPE_VIDEO:
           renderer = new VideoLayerRenderer(gbm.dev);
           break;
@@ -405,6 +406,7 @@ static void init_frames(int32_t width, int32_t height) {
         case LAYER_TYPE_GL_TEXTURE:
           renderer = new GLCubeLayerRenderer(gbm.dev, true);
           break;
+#endif
         default:
           printf("un-recognized layer type!\n");
           exit(-1);

--- a/tests/common/gllayerrenderer.cpp
+++ b/tests/common/gllayerrenderer.cpp
@@ -78,7 +78,11 @@ bool GLLayerRenderer::Init(uint32_t width, uint32_t height, uint32_t format,
 
   eglMakeCurrent(gl_->display, EGL_NO_SURFACE, EGL_NO_SURFACE, gl_->context);
 
+#ifdef USE_MINIGBM
   int gbm_bo_fd = native_handle_.import_data.fds[0];
+#else
+  int gbm_bo_fd = native_handle_.import_data.fd;
+#endif
   const EGLint image_attrs[] = {
       EGL_WIDTH,                    (EGLint)width,
       EGL_HEIGHT,                   (EGLint)height,

--- a/tests/common/layerrenderer.cpp
+++ b/tests/common/layerrenderer.cpp
@@ -16,6 +16,10 @@
 
 #include "layerrenderer.h"
 
+#ifndef USE_MINIGBM
+#include "gbmutils.h"
+#endif
+
 LayerRenderer::LayerRenderer(struct gbm_device* dev) {
   gbm_dev_ = dev;
 }
@@ -39,18 +43,28 @@ bool LayerRenderer::Init(uint32_t width, uint32_t height, uint32_t format,
     }
   }
 
+#if USE_MINIGBM
   int gbm_bo_fd = gbm_bo_get_plane_fd(gbm_bo_, 0);
+#else
+  int gbm_bo_fd = gbm_bo_get_fd(gbm_bo_);
+#endif
   if (gbm_bo_fd == -1) {
     ETRACE("LayerRenderer: gbm_bo_get_fd() failed");
     return false;
   }
 
+#if USE_MINIGBM
   planes_ = gbm_bo_get_num_planes(gbm_bo_);
   for (size_t i = 0; i < planes_; i++) {
     native_handle_.import_data.offsets[i] = gbm_bo_get_plane_offset(gbm_bo_, i);
     native_handle_.import_data.strides[i] = gbm_bo_get_plane_stride(gbm_bo_, i);
     native_handle_.import_data.fds[i] = gbm_bo_fd;
   }
+#else
+  planes_ = gbm_bo_get_num_planes(gbm_bo_get_format(gbm_bo_));
+  native_handle_.import_data.stride = gbm_bo_get_stride(gbm_bo_);
+  native_handle_.import_data.fd = gbm_bo_fd;
+#endif
 
   native_handle_.import_data.width = width;
   native_handle_.import_data.height = height;


### PR DESCRIPTION
I had earlier rebased this on commit - 11a3f4a0d5f418473705e99c6c9bfa33ff83151b

And there was no tearing whats so ever in the cube in dual display scenario. But after latest code pull, either of the display will have a tearing in centre of the cube. 

Anyways with gbm kmscube app works but only for some time after which it crashes. That investigation is pending. If you think this as experimental feature you can merge and I will push incremental fix, else you can wait for fix of the crash. But do provide early review comments.

**update**: With most recent code update, there is no crash seen. Looks like that was inherent problem with fd based changes that were done recently and are fixed now.