### PR TITLE
Confirm Validate display call before Accepting Display

### DIFF
--- a/common/core/gpudevice.cpp
+++ b/common/core/gpudevice.cpp
@@ -258,9 +258,9 @@ void GpuDevice::DisplayManager::HotPlugEventHandler() {
   CTRACE();
   char buffer[1024];
   int ret;
-  bool drm_event = false, hotplug_event = false;
 
   while (true) {
+    bool drm_event = false, hotplug_event = false;
     ret = read(hotplug_fd_.get(), &buffer, sizeof(buffer));
     if (ret == 0) {
       return;

--- a/common/display/display.cpp
+++ b/common/display/display.cpp
@@ -220,4 +220,8 @@ void Display::VSyncControl(bool enabled) {
   flip_handler_->VSyncControl(enabled);
 }
 
+bool Display::CheckPlaneFormat(uint32_t format) {
+  return display_queue_->CheckPlaneFormat(format);
+}
+
 }  // namespace hwcomposer

--- a/common/display/display.h
+++ b/common/display/display.h
@@ -87,6 +87,7 @@ class Display : public NativeDisplay {
                             uint32_t display_id) override;
 
   void VSyncControl(bool enabled) override;
+  bool CheckPlaneFormat(uint32_t format) override;
 
  protected:
   uint32_t CrtcId() const override {

--- a/common/display/displayplanemanager.cpp
+++ b/common/display/displayplanemanager.cpp
@@ -521,4 +521,8 @@ std::unique_ptr<DisplayPlane> DisplayPlaneManager::CreatePlane(
       new DisplayPlane(plane_id, possible_crtcs));
 }
 
+bool DisplayPlaneManager::CheckPlaneFormat(uint32_t format) {
+  return primary_plane_->IsSupportedFormat(format);
+}
+
 }  // namespace hwcomposer

--- a/common/display/displayplanemanager.h
+++ b/common/display/displayplanemanager.h
@@ -62,6 +62,7 @@ class DisplayPlaneManager {
   void DisablePipe(drmModeAtomicReqPtr property_set);
 
   void EndFrameUpdate();
+  bool CheckPlaneFormat(uint32_t format);
 
  protected:
   struct OverlayPlane {

--- a/common/display/displayqueue.cpp
+++ b/common/display/displayqueue.cpp
@@ -395,4 +395,8 @@ void DisplayQueue::GetDrmObjectProperty(const char* name,
     ETRACE("Could not find property %s", name);
 }
 
+bool DisplayQueue::CheckPlaneFormat(uint32_t format) {
+  return display_plane_manager_->CheckPlaneFormat(format);
+}
+
 }  // namespace hwcomposer

--- a/common/display/displayqueue.h
+++ b/common/display/displayqueue.h
@@ -51,6 +51,7 @@ class DisplayQueue : public HWCThread {
 
   bool QueueUpdate(std::vector<HwcLayer*>& source_layers);
   bool SetPowerMode(uint32_t power_mode);
+  bool CheckPlaneFormat(uint32_t format);
 
  protected:
   void HandleRoutine() override;

--- a/common/display/headless.cpp
+++ b/common/display/headless.cpp
@@ -129,4 +129,9 @@ int Headless::RegisterVsyncCallback(std::shared_ptr<VsyncCallback> /*callback*/,
 void Headless::VSyncControl(bool /*enabled*/) {
 }
 
+bool Headless::CheckPlaneFormat(uint32_t format) {
+  // assuming that virtual display supports the format
+  return true;
+}
+
 }  // namespace hwcomposer

--- a/common/display/headless.h
+++ b/common/display/headless.h
@@ -73,6 +73,7 @@ class Headless : public NativeDisplay {
                             uint32_t display_id) override;
 
   void VSyncControl(bool enabled) override;
+  bool CheckPlaneFormat(uint32_t format) override;
 
  protected:
   uint32_t CrtcId() const override {

--- a/os/android/drmhwctwo.cpp
+++ b/os/android/drmhwctwo.cpp
@@ -256,15 +256,20 @@ HWC2::Error DrmHwcTwo::HwcDisplay::GetChangedCompositionTypes(
   return HWC2::Error::None;
 }
 
-HWC2::Error DrmHwcTwo::HwcDisplay::GetClientTargetSupport(uint32_t /*width*/,
-                                                          uint32_t /*height*/,
-                                                          int32_t /*format*/,
+HWC2::Error DrmHwcTwo::HwcDisplay::GetClientTargetSupport(uint32_t width,
+                                                          uint32_t height,
+                                                          int32_t format,
                                                           int32_t dataspace) {
-  if (dataspace != HAL_DATASPACE_UNKNOWN &&
-      dataspace != HAL_DATASPACE_STANDARD_UNSPECIFIED)
+  if (width == display_->Width() && height == display_->Height() &&
+      format == HAL_PIXEL_FORMAT_RGBA_8888 &&
+      dataspace == HAL_DATASPACE_UNKNOWN) {
+      return HWC2::Error::None;
+    }
+  else if (!(display_->CheckPlaneFormat(format)) &&
+           dataspace != HAL_DATASPACE_UNKNOWN &&
+           dataspace != HAL_DATASPACE_STANDARD_UNSPECIFIED)
     return HWC2::Error::Unsupported;
 
-  // TODO: Validate format can be handled by either GL or planes
   return HWC2::Error::None;
 }
 

--- a/public/nativedisplay.h
+++ b/public/nativedisplay.h
@@ -82,6 +82,7 @@ class NativeDisplay {
   virtual void SetOutputBuffer(HWCNativeHandle /*buffer*/,
                                int32_t /*acquire_fence*/) {
   }
+  virtual bool CheckPlaneFormat(uint32_t format) = 0;
 
  protected:
   virtual uint32_t CrtcId() const = 0;


### PR DESCRIPTION
Changes.

Added a check to confirm ValidateDisplay is called
before AcceptDisplayChanges.

Jira: https://01.org/jira/browse/IAHWC-28
Test: No regression observed on Android.

Signed-off-by: Poornima <poornima.y.n@intel.com>