### PR TITLE
Hotplug event thread should resume itself

### DIFF
--- a/common/core/gpudevice.cpp
+++ b/common/core/gpudevice.cpp
@@ -413,7 +413,7 @@ bool GpuDevice::DisplayManager::UpdateDisplayState() {
     headless_.release();
   }
 
-  if (callback_ && !connected_displays_.empty()) {
+  if (callback_) {
     callback_->Callback(connected_displays_);
   }
 

--- a/common/core/gpudevice.cpp
+++ b/common/core/gpudevice.cpp
@@ -379,6 +379,7 @@ bool GpuDevice::DisplayManager::UpdateDisplayState() {
       }
     } else {
       // Try to find an encoder for the connector.
+      bool found_encoder = false;
       for (int32_t j = 0; j < connector->count_encoders; ++j) {
         ScopedDrmEncoderPtr encoder(
             drmModeGetEncoder(fd_, connector->encoders[j]));
@@ -390,10 +391,12 @@ bool GpuDevice::DisplayManager::UpdateDisplayState() {
               display->Connect(mode, connector.get(), buffer_handler_.get())) {
             IHOTPLUGEVENTTRACE("connected pipe:%d \n", display->Pipe());
             connected_displays_.emplace_back(display.get());
+            found_encoder = true;
             break;
           }
         }
       }
+      if(found_encoder) break;
     }
   }
 

--- a/common/core/gpudevice.cpp
+++ b/common/core/gpudevice.cpp
@@ -71,6 +71,7 @@ class GpuDevice::DisplayManager : public HWCThread {
       std::shared_ptr<DisplayHotPlugEventCallback> callback);
 
  protected:
+  void HandleWait() override;
   void HandleRoutine() override;
 
  private:
@@ -294,6 +295,9 @@ void GpuDevice::DisplayManager::HotPlugEventHandler() {
   }
 }
 #endif
+
+void GpuDevice::DisplayManager::HandleWait() {
+}
 
 void GpuDevice::DisplayManager::HandleRoutine() {
   CTRACE();


### PR DESCRIPTION
Hotplug issues
1) Thread is always waiting for signal
2) More than one encoder could be used for one connector
3) Empty displays does not get informed