### PR TITLE
Add surface damage support

### DIFF
--- a/common/core/hwclayer.cpp
+++ b/common/core/hwclayer.cpp
@@ -42,4 +42,8 @@ void HwcLayer::SetDisplayFrame(const HwcRect<int>& display_frame) {
   display_frame_ = display_frame;
 }
 
+void HwcLayer::SetSurfaceDamage(const HwcRegion& surface_damage) {
+  surface_damage_ = surface_damage;
+}
+
 }  // namespace hwcomposer

--- a/common/core/overlaylayer.cpp
+++ b/common/core/overlaylayer.cpp
@@ -118,6 +118,10 @@ void OverlayLayer::SetDisplayFrame(const HwcRect<int>& display_frame) {
   display_frame_ = display_frame;
 }
 
+void OverlayLayer::SetSurfaceDamage(const HwcRegion& surface_damage) {
+  surface_damage_ = surface_damage;
+}
+
 void OverlayLayer::Dump() {
   DUMPTRACE("OverlayLayer Information Starts. -------------");
   switch (blending_) {

--- a/common/core/overlaylayer.h
+++ b/common/core/overlaylayer.h
@@ -120,6 +120,11 @@ struct OverlayLayer {
     return display_frame_;
   }
 
+  void SetSurfaceDamage(const HwcRegion& surface_damage);
+  const HwcRegion GetSurfaceDamage() const {
+    return surface_damage_;
+  }
+
   uint32_t GetSourceCropWidth() const {
     return source_crop_width_;
   }
@@ -151,6 +156,7 @@ struct OverlayLayer {
   HWCNativeHandle sf_handle_ = 0;
   NativeSync::State state_ = NativeSync::State::kSignalOnPageFlipEvent;
   std::unique_ptr<ImportedBuffer> imported_buffer_;
+  HwcRegion surface_damage_;
 };
 
 }  // namespace hwcomposer

--- a/common/display/displayqueue.cpp
+++ b/common/display/displayqueue.cpp
@@ -208,9 +208,11 @@ bool DisplayQueue::QueueUpdate(std::vector<HwcLayer*>& source_layers,
   size_t size = source_layers.size();
   std::vector<OverlayLayer> layers;
   std::vector<HwcRect<int>> layers_rects;
+  bool validate = true;
 
   for (size_t layer_index = 0; layer_index < size; layer_index++) {
     HwcLayer* layer = source_layers.at(layer_index);
+    const HwcRegion &current_surface_damage = layer->GetSurfaceDamage();
     layers.emplace_back();
     OverlayLayer& overlay_layer = layers.back();
     overlay_layer.SetNativeHandle(layer->GetNativeHandle());
@@ -219,6 +221,7 @@ bool DisplayQueue::QueueUpdate(std::vector<HwcLayer*>& source_layers,
     overlay_layer.SetBlending(layer->GetBlending());
     overlay_layer.SetSourceCrop(layer->GetSourceCrop());
     overlay_layer.SetDisplayFrame(layer->GetDisplayFrame());
+    overlay_layer.SetSurfaceDamage(current_surface_damage);
     overlay_layer.SetIndex(layer_index);
     overlay_layer.SetAcquireFence(layer->acquire_fence.Release());
     layers_rects.emplace_back(layer->GetDisplayFrame());
@@ -228,6 +231,29 @@ bool DisplayQueue::QueueUpdate(std::vector<HwcLayer*>& source_layers,
     int ret = layer->release_fence.Reset(overlay_layer.GetReleaseFence());
     if (ret < 0)
       ETRACE("Failed to create fence for layer, error: %s", PRINTERROR());
+
+    //check the surafce damage if its 0 for all layers then skip validate
+    // and commit
+    if (current_surface_damage.kNumRects == 1) {
+      const HwcRect<int> *rect = current_surface_damage.kRects;
+      if ((rect->top == 0) && (rect->bottom == 0) && (rect->left == 0) &&
+          (rect->right == 0)) {
+        const HwcRect<int> &previous = previous_layers_.at(layer_index).GetDisplayFrame();
+        const HwcRect<int> &current = layer->GetDisplayFrame();
+        if ((previous.left != current.left) || (previous.top != current.top)) {
+          validate = true;
+        } else {
+          validate = false;
+        }
+      }
+    } else if (current_surface_damage.kNumRects == 0) {
+      validate = true;
+    }
+  }
+
+  if (!validate) {
+    buffer_manager_->UnRegisterLayerBuffers(layers);
+    return true;
   }
 
   // Reset any DisplayQueue Manager and Compositor state.

--- a/os/android/drmhwctwo.cpp
+++ b/os/android/drmhwctwo.cpp
@@ -683,8 +683,19 @@ HWC2::Error DrmHwcTwo::HwcLayer::SetLayerSourceCrop(hwc_frect_t crop) {
 
 HWC2::Error DrmHwcTwo::HwcLayer::SetLayerSurfaceDamage(hwc_region_t damage) {
   supported(__func__);
-  // TODO: We don't use surface damage, marking as unsupported
-  unsupported(__func__, damage);
+
+  std::vector<hwcomposer::HwcRect<int>> hwc_rects;
+
+  for (size_t rect = 0; rect < damage.numRects; ++rect) {
+    hwc_rects.push_back({damage.rects[rect].left, damage.rects[rect].top,
+                         damage.rects[rect].right, damage.rects[rect].bottom});
+  }
+
+  hwcomposer::HwcRegion hwc_region = {};
+  hwc_region.kNumRects = damage.numRects;
+  hwc_region.kRects = hwc_rects.data();
+
+  hwc_layer_.SetSurfaceDamage(hwc_region);
   return HWC2::Error::None;
 }
 

--- a/public/hwcdefs.h
+++ b/public/hwcdefs.h
@@ -26,6 +26,11 @@ namespace hwcomposer {
 template <typename T>
 using HwcRect = Rect<T>;
 
+struct HwcRegion {
+  uint32_t kNumRects;
+  HwcRect<int> const* kRects;
+};
+
 enum class HWCBlending : int32_t {
   kBlendingNone = 0x0100,
   kBlendingPremult = 0x0105,

--- a/public/hwclayer.h
+++ b/public/hwclayer.h
@@ -62,6 +62,11 @@ struct HwcLayer {
     return display_frame_;
   }
 
+  void SetSurfaceDamage(const HwcRegion& surface_damage);
+  const HwcRegion& GetSurfaceDamage() const {
+    return surface_damage_;
+  }
+
  private:
   uint32_t transform_ = 0;
   uint8_t alpha_ = 0xff;
@@ -69,6 +74,7 @@ struct HwcLayer {
   HwcRect<int> display_frame_;
   HWCBlending blending_ = HWCBlending::kBlendingNone;
   HWCNativeHandle sf_handle_ = 0;
+  HwcRegion surface_damage_;
 };
 
 }  // namespace hwcomposer


### PR DESCRIPTION
Added the basic support to avoid the complete validate and present
if the given layers are same as previous one.

Jira: IAHWC-36
Test: No regressions with Linux app and on Android

Signed-off-by: Pallavi G <pallavi.g@intel.com>