### PR TITLE
Add nv12 support

### DIFF
--- a/common/core/overlaybuffer.cpp
+++ b/common/core/overlaybuffer.cpp
@@ -65,23 +65,40 @@ GpuImage OverlayBuffer::ImportImage(GpuDisplay egl_display) {
   // Note: If eglCreateImageKHR is successful for a EGL_LINUX_DMA_BUF_EXT
   // target, the EGL will take a reference to the dma_buf.
   if (is_yuv_) {
-    const EGLint attr_list_yv12[] = {
-        EGL_WIDTH,                     static_cast<EGLint>(width_),
-        EGL_HEIGHT,                    static_cast<EGLint>(height_),
-        EGL_LINUX_DRM_FOURCC_EXT,      static_cast<EGLint>(format_),
-        EGL_DMA_BUF_PLANE0_FD_EXT,     static_cast<EGLint>(prime_fd_),
-        EGL_DMA_BUF_PLANE0_PITCH_EXT,  static_cast<EGLint>(pitches_[0]),
-        EGL_DMA_BUF_PLANE0_OFFSET_EXT, static_cast<EGLint>(offsets_[0]),
-        EGL_DMA_BUF_PLANE1_FD_EXT,     static_cast<EGLint>(prime_fd_),
-        EGL_DMA_BUF_PLANE1_PITCH_EXT,  static_cast<EGLint>(pitches_[1]),
-        EGL_DMA_BUF_PLANE1_OFFSET_EXT, static_cast<EGLint>(offsets_[1]),
-        EGL_DMA_BUF_PLANE2_FD_EXT,     static_cast<EGLint>(prime_fd_),
-        EGL_DMA_BUF_PLANE2_PITCH_EXT,  static_cast<EGLint>(pitches_[2]),
-        EGL_DMA_BUF_PLANE2_OFFSET_EXT, static_cast<EGLint>(offsets_[2]),
-        EGL_NONE,                      0};
-    image = eglCreateImageKHR(
-        egl_display, EGL_NO_CONTEXT, EGL_LINUX_DMA_BUF_EXT,
-        static_cast<EGLClientBuffer>(nullptr), attr_list_yv12);
+    if (format_ == DRM_FORMAT_NV12) {
+      const EGLint attr_list_nv12[] = {
+          EGL_WIDTH,                     static_cast<EGLint>(width_),
+          EGL_HEIGHT,                    static_cast<EGLint>(height_),
+          EGL_LINUX_DRM_FOURCC_EXT,      static_cast<EGLint>(format_),
+          EGL_DMA_BUF_PLANE0_FD_EXT,     static_cast<EGLint>(prime_fd_),
+          EGL_DMA_BUF_PLANE0_PITCH_EXT,  static_cast<EGLint>(pitches_[0]),
+          EGL_DMA_BUF_PLANE0_OFFSET_EXT, static_cast<EGLint>(offsets_[0]),
+          EGL_DMA_BUF_PLANE1_FD_EXT,     static_cast<EGLint>(prime_fd_),
+          EGL_DMA_BUF_PLANE1_PITCH_EXT,  static_cast<EGLint>(pitches_[1]),
+          EGL_DMA_BUF_PLANE1_OFFSET_EXT, static_cast<EGLint>(offsets_[1]),
+          EGL_NONE,                      0};
+      image = eglCreateImageKHR(
+          egl_display, EGL_NO_CONTEXT, EGL_LINUX_DMA_BUF_EXT,
+          static_cast<EGLClientBuffer>(nullptr), attr_list_nv12);
+    } else {
+      const EGLint attr_list_yv12[] = {
+          EGL_WIDTH,                     static_cast<EGLint>(width_),
+          EGL_HEIGHT,                    static_cast<EGLint>(height_),
+          EGL_LINUX_DRM_FOURCC_EXT,      static_cast<EGLint>(format_),
+          EGL_DMA_BUF_PLANE0_FD_EXT,     static_cast<EGLint>(prime_fd_),
+          EGL_DMA_BUF_PLANE0_PITCH_EXT,  static_cast<EGLint>(pitches_[0]),
+          EGL_DMA_BUF_PLANE0_OFFSET_EXT, static_cast<EGLint>(offsets_[0]),
+          EGL_DMA_BUF_PLANE1_FD_EXT,     static_cast<EGLint>(prime_fd_),
+          EGL_DMA_BUF_PLANE1_PITCH_EXT,  static_cast<EGLint>(pitches_[1]),
+          EGL_DMA_BUF_PLANE1_OFFSET_EXT, static_cast<EGLint>(offsets_[1]),
+          EGL_DMA_BUF_PLANE1_FD_EXT,     static_cast<EGLint>(prime_fd_),
+          EGL_DMA_BUF_PLANE1_PITCH_EXT,  static_cast<EGLint>(pitches_[2]),
+          EGL_DMA_BUF_PLANE1_OFFSET_EXT, static_cast<EGLint>(offsets_[2]),
+          EGL_NONE,                      0};
+      image = eglCreateImageKHR(
+          egl_display, EGL_NO_CONTEXT, EGL_LINUX_DMA_BUF_EXT,
+          static_cast<EGLClientBuffer>(nullptr), attr_list_yv12);
+    }
   } else {
     const EGLint attr_list[] = {
         EGL_WIDTH,                     static_cast<EGLint>(width_),

--- a/os/linux/gbmbufferhandler.cpp
+++ b/os/linux/gbmbufferhandler.cpp
@@ -99,6 +99,13 @@ bool GbmBufferHandler::ImportBuffer(HWCNativeHandle handle, HwcBuffer *bo) {
   if (!handle->bo) {
     handle->bo = gbm_bo_import(device_, GBM_BO_IMPORT_FD_PLANAR,
                                &handle->import_data, GBM_BO_USE_SCANOUT);
+    if (!handle->bo) {
+      handle->bo = gbm_bo_import(device_, GBM_BO_IMPORT_FD_PLANAR,
+                                 &handle->import_data, GBM_BO_USE_RENDERING);
+      if (!handle->bo) {
+        ETRACE("can't import bo");
+      }
+    }
   }
 
   gem_handle = gbm_bo_get_handle(handle->bo).u32;

--- a/tests/common/layerrenderer.cpp
+++ b/tests/common/layerrenderer.cpp
@@ -31,13 +31,17 @@ bool LayerRenderer::Init(uint32_t width, uint32_t height, uint32_t format,
   gbm_bo_ = gbm_bo_create(gbm_dev_, width, height, format,
                           GBM_BO_USE_SCANOUT | GBM_BO_USE_RENDERING);
   if (!gbm_bo_) {
-    printf("LayerRenderer: failed to create gbm_bo\n");
-    return false;
+    gbm_bo_ =
+        gbm_bo_create(gbm_dev_, width, height, format, GBM_BO_USE_RENDERING);
+    if (!gbm_bo_) {
+      ETRACE("LayerRenderer: failed to create gbm_bo");
+      return false;
+    }
   }
 
   int gbm_bo_fd = gbm_bo_get_plane_fd(gbm_bo_, 0);
   if (gbm_bo_fd == -1) {
-    printf("LayerRenderer: gbm_bo_get_fd() failed\n");
+    ETRACE("LayerRenderer: gbm_bo_get_fd() failed");
     return false;
   }
 

--- a/tests/jsonconfigs/video1layer_nv12.json
+++ b/tests/jsonconfigs/video1layer_nv12.json
@@ -1,0 +1,23 @@
+[{
+  "type":1,
+  "format":47,
+  "transform":0,
+  "resourcePath":"./resources/test.640x360.nv12",
+  "source": {
+    "width":640,
+    "height":360,
+    "crop": {
+      "x":0,
+      "y":0,
+      "width":640,
+      "height":360
+    }
+  },
+  "frame": {
+    "x":0,
+    "y":0,
+    "width":640,
+    "height":360
+  }
+}
+]


### PR DESCRIPTION
NV12 is not supported as SCANOUT in older platforms, so try to use RENDERING only;
Some logic should be change in overlaybuffer ImportImage, as NV12 is 2 plane sformat
JIRA:  IAHWC-52
Tests: testlayers -j jsonconfigs/video1layer_nv12.json