### PR TITLE
vk: Define missing Renderer overrides

### DIFF
--- a/common/compositor/vk/vkrenderer.cpp
+++ b/common/compositor/vk/vkrenderer.cpp
@@ -683,6 +683,13 @@ void VKRenderer::InsertFence(uint64_t kms_fence) {
 #endif
 }
 
+void VKRenderer::RestoreState() {
+}
+
+bool VKRenderer::MakeCurrent() {
+  return true;
+}
+
 VKProgram *VKRenderer::GetProgram(unsigned texture_count) {
   if (programs_.size() >= texture_count) {
     VKProgram *program = programs_[texture_count - 1].get();

--- a/common/compositor/vk/vkrenderer.h
+++ b/common/compositor/vk/vkrenderer.h
@@ -32,6 +32,8 @@ class VKRenderer : public Renderer {
   bool Draw(const std::vector<RenderState> &commands,
             NativeSurface *surface) override;
   void InsertFence(uint64_t kms_fence) override;
+  void RestoreState() override;
+  bool MakeCurrent() override;
 
  private:
   VKProgram *GetProgram(unsigned texture_count);


### PR DESCRIPTION
Since commit 78a230016b RestoreState() and MakeCurrent() are required to be
redefined in classes inheriting from Renderer. There doesn't appear to be
anything needed from Vulkan for these calls, so for now add noop overrides
to make the build green again.

Jira: IAHWC-40
Test: Vulkan backend compiles

Signed-off-by: Kevin Strasser <kevin.strasser@intel.com>