### PR TITLE
vk: Make each VKSurface track its own fb

### DIFF
--- a/common/compositor/vk/vkshim.cpp
+++ b/common/compositor/vk/vkshim.cpp
@@ -24,8 +24,6 @@ VkRenderPass render_pass_;
 VkPipelineCache pipeline_cache_;
 VkBuffer uniform_buffer_;
 VkSampler sampler_;
-VkImage dst_image_;
-VkImageView dst_image_view_;
 std::vector<VkImage> src_images_;
 std::vector<VkImageView> src_image_views_;
 std::vector<VkDescriptorImageInfo> src_image_infos_;

--- a/common/compositor/vk/vkshim.h
+++ b/common/compositor/vk/vkshim.h
@@ -135,8 +135,6 @@ extern VkRenderPass render_pass_;
 extern VkPipelineCache pipeline_cache_;
 extern VkBuffer uniform_buffer_;
 extern VkSampler sampler_;
-extern VkImage dst_image_;
-extern VkImageView dst_image_view_;
 extern std::vector<VkImage> src_images_;
 extern std::vector<VkImageView> src_image_views_;
 extern std::vector<VkDescriptorImageInfo> src_image_infos_;

--- a/common/compositor/vk/vksurface.h
+++ b/common/compositor/vk/vksurface.h
@@ -33,6 +33,7 @@ class VKSurface : public NativeSurface {
 
  private:
   bool InitializeGPUResources();
+  VkFramebuffer surface_fb_;
 };
 
 }  // namespace hwcomposer


### PR DESCRIPTION
Only 1 framebuffer is being created as it's being tracked at global scope.
Add a member field to VKSurface so each instance has its own fb, and then
assign it to the global target during MakeCurrent().

While we're at it, remove dst_image_ and dst_image_view_ from global scope,
as they are only ever used inside vksurface.

Jira: IAHWC-40
Test: Try demo apps and check that there is no flickering

Signed-off-by: Kevin Strasser <kevin.strasser@intel.com>