### PR TITLE
[RFC] Enable runtime backend selection

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -90,9 +90,6 @@ LOCAL_CPPFLAGS += -DDISABLE_OVERLAY_USAGE
 endif
 
 ifeq ($(strip $(BOARD_USES_VULKAN)),)
-LOCAL_CPPFLAGS += \
-	-DUSE_GL
-
 LOCAL_SRC_FILES += \
 	common/compositor/gl/glprogram.cpp \
 	common/compositor/gl/glrenderer.cpp \

--- a/Makefile.am
+++ b/Makefile.am
@@ -26,7 +26,7 @@ SUBDIRS = \
 
 MAINTAINERCLEANFILES = ChangeLog INSTALL
 
-AM_CPP_INCLUDES = -I$(top_srcdir) -Ipublic -Icommon/core -Icommon/utils -Icommon/compositor -Icommon/display  -Ios/linux -Icommon/compositor/gl -Itests/common
+AM_CPP_INCLUDES = -I$(top_srcdir) -Ipublic -Icommon/core -Icommon/utils -Icommon/compositor -Icommon/display  -Ios/linux -Icommon/compositor/gl -Icommon/compositor/vk -Itests/common
 AM_CPPFLAGS = -std=c++11 -fPIC -O2 -D_FORTIFY_SOURCE=2 -fstack-protector-strong -fPIE
 AM_CPPFLAGS += $(AM_CPP_INCLUDES) $(CWARNFLAGS) $(DRM_CFLAGS) $(DEBUG_CFLAGS) -Wformat -Wformat-security
 
@@ -43,17 +43,13 @@ libhwcomposer_la_LIBADD = \
 	$(GBM_LIBS) \
 	$(EGL_LIBS) \
 	$(GLES2_LIBS) \
+	-lvulkan \
 	-lm
 
 libhwcomposer_la_LTLIBRARIES = libhwcomposer.la
-libhwcomposer_la_SOURCES = $(common_SOURCES)
+libhwcomposer_la_SOURCES = $(common_SOURCES) $(vk_SOURCES) $(gl_SOURCES)
 if ENABLE_VULKAN
-libhwcomposer_la_SOURCES += $(vk_SOURCES)
-AM_CPPFLAGS += -Icommon/compositor/vk -DUSE_VK -DDISABLE_EXPLICIT_SYNC
-libhwcomposer_la_LIBADD += -lvulkan
-else
-libhwcomposer_la_SOURCES += $(gl_SOURCES)
-AM_CPPFLAGS += -DUSE_GL
+AM_CPPFLAGS += -DUSE_VK -DDISABLE_EXPLICIT_SYNC
 endif
 libhwcomposer_ladir = $(libdir)
 libhwcomposer_la_LDFLAGS = -version-number 0:0:1 -no-undefined -static

--- a/common/compositor/compositor.cpp
+++ b/common/compositor/compositor.cpp
@@ -47,7 +47,7 @@ bool Compositor::BeginFrame() {
   if (!renderer_) {
     renderer_.reset(CreateRenderer());
     if (!renderer_->Init()) {
-      ETRACE("Failed to initialize OpenGL compositor %s", PRINTERROR());
+      ETRACE("Failed to initialize compositor %s", PRINTERROR());
       renderer_.reset(nullptr);
       return false;
     }

--- a/common/compositor/compositordefs.h
+++ b/common/compositor/compositordefs.h
@@ -19,11 +19,8 @@
 
 #include <stdint.h>
 
-#ifdef USE_GL
-#include "shim.h"
-#elif USE_VK
 #include "vkshim.h"
-#endif
+#include "shim.h"
 
 namespace hwcomposer {
 
@@ -37,28 +34,21 @@ static float TransformMatrices[] = {
     0.0f, 1.0f, 1.0f, 0.0f,  // swap x and y
 };
 // clang-format on
-
-#ifdef USE_GL
-typedef unsigned GpuResourceHandle;
-typedef EGLImageKHR GpuImage;
-typedef EGLDisplay GpuDisplay;
-#elif USE_VK
-typedef struct vk_resource {
+struct vk_resource {
   VkImage image;
   VkImageView image_view;
-} GpuResourceHandle;
-typedef struct vk_import {
+};
+
+struct vk_import {
   VkImage image;
   VkDeviceMemory memory;
   VkResult res;
-} GpuImage;
+};
 
-typedef VkDevice GpuDisplay;
-#else
-typedef unsigned GpuResourceHandle;
-typedef void* GpuImage;
-typedef void* GpuDisplay;
-#endif
+union GpuResourceHandle {
+  unsigned gl;
+  struct vk_resource vk;
+};
 
 }  // namespace hwcomposer
 #endif  // COMMON_COMPOSITOR_COMPOSITORDEFS_H_

--- a/common/compositor/factory.cpp
+++ b/common/compositor/factory.cpp
@@ -17,46 +17,115 @@
 #include "factory.h"
 #include "platformdefines.h"
 
-#ifdef USE_GL
 #include "glrenderer.h"
 #include "glsurface.h"
 #include "nativeglresource.h"
-#elif USE_VK
+
 #include "nativevkresource.h"
 #include "vkrenderer.h"
 #include "vksurface.h"
-#endif
 
 namespace hwcomposer {
 
-NativeSurface* CreateBackBuffer(uint32_t width, uint32_t height) {
-#ifdef USE_GL
+static NativeSurface* create_gl_surface(uint32_t width, uint32_t height) {
   return new GLSurface(width, height);
-#elif USE_VK
+}
+
+static Renderer* create_gl_renderer() {
+  return new GLRenderer();
+}
+
+static NativeGpuResource* create_gl_resource() {
+  return new NativeGLResource();
+}
+
+static NativeSurface* create_vk_surface(uint32_t width, uint32_t height) {
   return new VKSurface(width, height);
+}
+
+static Renderer* create_vk_renderer() {
+  return new VKRenderer();
+}
+
+static NativeGpuResource* create_vk_resource() {
+  return new NativeVKResource();
+}
+
+struct backend {
+  char const *id;
+  NativeSurface* (*create_surface)(uint32_t width, uint32_t height);
+  Renderer* (*create_renderer)(void);
+  NativeGpuResource* (*create_resource)(void);
+};
+
+static struct backend backends[] = {
+#ifdef USE_VK
+  {"VK", create_vk_surface, create_vk_renderer, create_vk_resource},
+  {"GL", create_gl_surface, create_gl_renderer, create_gl_resource},
 #else
-  return NULL;
+  {"GL", create_gl_surface, create_gl_renderer, create_gl_resource},
+  {"VK", create_vk_surface, create_vk_renderer, create_vk_resource},
 #endif
+  {}
+};
+
+static struct backend *active_backend = NULL;
+
+NativeSurface* CreateBackBuffer(uint32_t width, uint32_t height) {
+  if (active_backend) {
+    return active_backend->create_surface(width, height);
+  }
+
+  for (struct backend *be = backends; be->id; be++) {
+    NativeSurface *surf = be->create_surface(width, height);
+    if (surf) {
+      ETRACE("Selecting %s backend\n", be->id);
+      active_backend = be;
+      return surf;
+    }
+    ETRACE("Failed to create surface for %s backend\n", be->id);
+  }
+
+  ETRACE("Failed to create a NativeSuface\n");
+  return NULL;
 }
 
 Renderer* CreateRenderer() {
-#ifdef USE_GL
-  return new GLRenderer();
-#elif USE_VK
-  return new VKRenderer();
-#else
+  if (active_backend) {
+    return active_backend->create_renderer();
+  }
+
+  for (struct backend *be = backends; be->id; be++) {
+    Renderer *renderer = be->create_renderer();
+    if (renderer) {
+      ETRACE("Selecting %s backend\n", be->id);
+      active_backend = be;
+      return renderer;
+    }
+    ETRACE("Failed to create Renderer for %s backend\n", be->id);
+  }
+
+  ETRACE("Failed to create a Renderer\n");
   return NULL;
-#endif
 }
 
 NativeGpuResource* CreateNativeGpuResourceHandler() {
-#ifdef USE_GL
-  return new NativeGLResource();
-#elif USE_VK
-  return new NativeVKResource();
-#else
+  if (active_backend) {
+    return active_backend->create_resource();
+  }
+
+  for (struct backend *be = backends; be->id; be++) {
+    NativeGpuResource *resource = be->create_resource();
+    if (resource) {
+      ETRACE("Selecting %s backend\n", be->id);
+      active_backend = be;
+      return resource;
+    }
+    ETRACE("Failed to create NativeGpuResource for %s backend\n", be->id);
+  }
+
+  ETRACE("Failed to create a NativeGpuResource\n");
   return NULL;
-#endif
 }
 
 }  // namespace hwcomposer

--- a/common/compositor/gl/glprogram.cpp
+++ b/common/compositor/gl/glprogram.cpp
@@ -241,7 +241,7 @@ void GLProgram::UseProgram(const RenderState &state, GLuint viewport_width,
     glUniformMatrix2fv(tex_matrix_loc_ + src_index, 1, GL_FALSE,
                        src.texture_matrix_);
     glActiveTexture(GL_TEXTURE0 + src_index);
-    glBindTexture(GL_TEXTURE_EXTERNAL_OES, src.handle_);
+    glBindTexture(GL_TEXTURE_EXTERNAL_OES, src.handle_.gl);
   }
 }
 

--- a/common/compositor/gl/nativeglresource.cpp
+++ b/common/compositor/gl/nativeglresource.cpp
@@ -25,7 +25,7 @@ namespace hwcomposer {
 bool NativeGLResource::PrepareResources(
     const std::vector<OverlayLayer>& layers) {
   Reset();
-  std::vector<GLuint>().swap(layer_textures_);
+  std::vector<GpuResourceHandle>().swap(layer_textures_);
   EGLDisplay egl_display = eglGetCurrentDisplay();
   for (auto& layer : layers) {
     // Create EGLImage.
@@ -44,7 +44,9 @@ bool NativeGLResource::PrepareResources(
     glTexParameteri(GL_TEXTURE_EXTERNAL_OES, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
     glTexParameteri(GL_TEXTURE_EXTERNAL_OES, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
     glBindTexture(GL_TEXTURE_EXTERNAL_OES, 0);
-    layer_textures_.emplace_back(texture);
+    GpuResourceHandle resource;
+    resource.gl = texture;
+    layer_textures_.emplace_back(resource);
     eglDestroyImageKHR(egl_display, egl_image);
   }
 
@@ -59,15 +61,18 @@ void NativeGLResource::Reset() {
   GLuint texture_id = 0;
   size_t size = layer_textures_.size();
   for (size_t i = 0; i < size; i++) {
-    texture_id = layer_textures_.at(i);
+    texture_id = layer_textures_.at(i).gl;
     glDeleteTextures(1, &texture_id);
   }
 }
 
 GpuResourceHandle NativeGLResource::GetResourceHandle(
     uint32_t layer_index) const {
-  if (layer_textures_.size() < layer_index)
-    return 0;
+  if (layer_textures_.size() < layer_index) {
+    GpuResourceHandle res;
+    res.gl = 0;
+    return res;
+  }
 
   return layer_textures_.at(layer_index);
 }

--- a/common/compositor/gl/nativeglresource.h
+++ b/common/compositor/gl/nativeglresource.h
@@ -36,7 +36,7 @@ class NativeGLResource : public NativeGpuResource {
 
  private:
   void Reset();
-  std::vector<GLuint> layer_textures_;
+  std::vector<GpuResourceHandle> layer_textures_;
 };
 
 }  // namespace hwcomposer

--- a/common/compositor/vk/nativevkresource.cpp
+++ b/common/compositor/vk/nativevkresource.cpp
@@ -75,9 +75,9 @@ bool NativeVKResource::PrepareResources(
     }
     src_image_views_.emplace_back(image_view);
 
-    struct vk_resource resource;
-    resource.image = import.image;
-    resource.image_view = image_view;
+    GpuResourceHandle resource;
+    resource.vk.image = import.image;
+    resource.vk.image_view = image_view;
     layer_textures_.emplace_back(resource);
   }
   return true;
@@ -110,7 +110,8 @@ void NativeVKResource::Reset() {
 GpuResourceHandle NativeVKResource::GetResourceHandle(
     uint32_t layer_index) const {
   if (layer_textures_.size() < layer_index) {
-    struct vk_resource res = {};
+    GpuResourceHandle res;
+    res.vk = {};
     return res;
   }
 

--- a/common/compositor/vk/nativevkresource.h
+++ b/common/compositor/vk/nativevkresource.h
@@ -32,7 +32,7 @@ class NativeVKResource : public NativeGpuResource {
 
  private:
   void Reset();
-  std::vector<struct vk_resource> layer_textures_;
+  std::vector<GpuResourceHandle> layer_textures_;
   std::vector<VkDeviceMemory> src_image_memory_;
 };
 

--- a/common/compositor/vk/vkprogram.cpp
+++ b/common/compositor/vk/vkprogram.cpp
@@ -275,7 +275,7 @@ void VKProgram::UseProgram(const RenderState &state,
 
     VkDescriptorImageInfo image_info = {};
     image_info.sampler = sampler_;
-    image_info.imageView = src.handle_.image_view;
+    image_info.imageView = src.handle_.vk.image_view;
     image_info.imageLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
     src_image_infos_.emplace_back(image_info);
   }

--- a/common/core/overlaybuffer.cpp
+++ b/common/core/overlaybuffer.cpp
@@ -59,8 +59,45 @@ void OverlayBuffer::InitializeFromNativeHandle(
   Initialize(bo);
 }
 
-GpuImage OverlayBuffer::ImportImage(GpuDisplay egl_display) {
-#ifdef USE_GL
+struct vk_import OverlayBuffer::ImportImage(VkDevice dev) {
+  struct vk_import import;
+
+  PFN_vkCreateDmaBufImageINTEL vkCreateDmaBufImageINTEL =
+      (PFN_vkCreateDmaBufImageINTEL)vkGetDeviceProcAddr(
+          dev, "vkCreateDmaBufImageINTEL");
+  if (vkCreateDmaBufImageINTEL == NULL) {
+    ETRACE("vkGetDeviceProcAddr(\"vkCreateDmaBufImageINTEL\") failed\n");
+    import.res = VK_ERROR_INITIALIZATION_FAILED;
+    return import;
+  }
+
+  VkFormat vk_format = GbmToVkFormat(format_);
+  if (vk_format == VK_FORMAT_UNDEFINED) {
+    ETRACE("Failed DRM -> Vulkan format conversion\n");
+    import.res = VK_ERROR_FORMAT_NOT_SUPPORTED;
+    return import;
+  }
+
+  VkExtent3D image_extent = {};
+  image_extent.width = width_;
+  image_extent.height = height_;
+  image_extent.depth = 1;
+
+  VkDmaBufImageCreateInfo image_create = {};
+  image_create.sType =
+      (enum VkStructureType)VK_STRUCTURE_TYPE_DMA_BUF_IMAGE_CREATE_INFO_INTEL;
+  image_create.fd = static_cast<int>(prime_fd_);
+  image_create.format = vk_format;
+  image_create.extent = image_extent;
+  image_create.strideInBytes = pitches_[0];
+
+  import.res = vkCreateDmaBufImageINTEL(dev, &image_create, NULL,
+                                        &import.memory, &import.image);
+
+  return import;
+}
+
+EGLImageKHR OverlayBuffer::ImportImage(EGLDisplay egl_display) {
   EGLImageKHR image = EGL_NO_IMAGE_KHR;
   // Note: If eglCreateImageKHR is successful for a EGL_LINUX_DMA_BUF_EXT
   // target, the EGL will take a reference to the dma_buf.
@@ -114,45 +151,6 @@ GpuImage OverlayBuffer::ImportImage(GpuDisplay egl_display) {
   }
 
   return image;
-#elif USE_VK
-  struct vk_import import;
-
-  PFN_vkCreateDmaBufImageINTEL vkCreateDmaBufImageINTEL =
-      (PFN_vkCreateDmaBufImageINTEL)vkGetDeviceProcAddr(
-          egl_display, "vkCreateDmaBufImageINTEL");
-  if (vkCreateDmaBufImageINTEL == NULL) {
-    ETRACE("vkGetDeviceProcAddr(\"vkCreateDmaBufImageINTEL\") failed\n");
-    import.res = VK_ERROR_INITIALIZATION_FAILED;
-    return import;
-  }
-
-  VkFormat vk_format = GbmToVkFormat(format_);
-  if (vk_format == VK_FORMAT_UNDEFINED) {
-    ETRACE("Failed DRM -> Vulkan format conversion\n");
-    import.res = VK_ERROR_FORMAT_NOT_SUPPORTED;
-    return import;
-  }
-
-  VkExtent3D image_extent = {};
-  image_extent.width = width_;
-  image_extent.height = height_;
-  image_extent.depth = 1;
-
-  VkDmaBufImageCreateInfo image_create = {};
-  image_create.sType =
-      (enum VkStructureType)VK_STRUCTURE_TYPE_DMA_BUF_IMAGE_CREATE_INFO_INTEL;
-  image_create.fd = static_cast<int>(prime_fd_);
-  image_create.format = vk_format;
-  image_create.extent = image_extent;
-  image_create.strideInBytes = pitches_[0];
-
-  import.res = vkCreateDmaBufImageINTEL(egl_display, &image_create, NULL,
-                                        &import.memory, &import.image);
-
-  return import;
-#else
-  return NULL;
-#endif
 }
 
 void OverlayBuffer::SetRecommendedFormat(uint32_t format) {

--- a/common/core/overlaybuffer.h
+++ b/common/core/overlaybuffer.h
@@ -62,7 +62,8 @@ class OverlayBuffer {
     return fb_id_;
   }
 
-  GpuImage ImportImage(GpuDisplay egl_display);
+  EGLImageKHR ImportImage(EGLDisplay egl_display);
+  struct vk_import ImportImage(VkDevice dev);
 
   bool CreateFrameBuffer(uint32_t gpu_fd);
 


### PR DESCRIPTION
Now that there are two functional compositor backends, it makes sense to
allow for them to coexist in a single build. If they are both built in by
default it is more likely that we will catch build breakages sooner, and it
allows us to have a fallback backend in production.

We are currently exposing three classes per backend, which creates a
challenge as it makes sense for a backend to be in charge of probing for
support, but it should be all-or-nothing, or else we might end up with mixed
objects.

This change explicitly groups factory functions for each backend and binds a
grouping once one of its factories succeeds in creating an object. The
caller doesn't have an obligation to create any particular object first, so
backends will need to do be able to probe for support in any order. We
aren't currently doing any probing in the relevant contructor functions, so
for now we will always just select the backend that is listed first.

The GL backend is selected by default, with VK as a fallback. This order may
change once Vulkan becomes more viable.  Also, in the future we can add
getter/setter functions to enable forcing a particular backend at runtime.

Jira: IAHWC-40
Test: Both backends are still working with demo apps

Signed-off-by: Kevin Strasser <kevin.strasser@intel.com>