### PR TITLE
HWC: Add spinlock for scopedfd

### DIFF
--- a/public/scopedfd.h
+++ b/public/scopedfd.h
@@ -18,6 +18,7 @@
 #define PUBLIC_SCOPEDFD_H_
 
 #include <unistd.h>
+#include "spinlock.h"
 
 namespace hwcomposer {
 
@@ -37,27 +38,35 @@ class ScopedFd {
   }
 
   ~ScopedFd() {
+    spin_lock_.lock();
     if (fd_ > 0)
       close(fd_);
+    spin_lock_.unlock();
   }
 
   int Release() {
+    spin_lock_.lock();
     int old_fd = fd_;
     fd_ = -1;
+    spin_lock_.unlock();
     return old_fd;
   }
 
   int Reset(int fd) {
+    spin_lock_.lock();
     if (fd_ > 0)
       close(fd_);
     fd_ = fd;
+    spin_lock_.unlock();
     return fd_;
   }
 
   void Close() {
+    spin_lock_.lock();
     if (fd_ > 0)
       close(fd_);
     fd_ = -1;
+    spin_lock_.unlock();
   }
 
   int get() const {
@@ -65,6 +74,7 @@ class ScopedFd {
   }
 
  private:
+  SpinLock spin_lock_;
   int fd_ = -1;
 };
 


### PR DESCRIPTION
The fence fd will be accessed/udpated by surfaceflinger main and
binder thread, and race condition may cause binder sessin crash

Test: run 3d gles and vulkan app without tearing
JIRA: https://01.org/jira/browse/AIA-332

Signed-off-by: Randy Xu <randy.xu@intel.com>