### PR TITLE
Store size of the static buffer in a variable

### DIFF
--- a/common/core/gpudevice.cpp
+++ b/common/core/gpudevice.cpp
@@ -164,20 +164,21 @@ bool GpuDevice::DisplayManager::Init(uint32_t fd) {
 
 void GpuDevice::DisplayManager::HotPlugEventHandler() {
   CTRACE();
-  char buffer[1024];
+  uint32_t buffer_size = 1024;
+  char buffer[buffer_size];
   int ret;
 
   while (true) {
     bool drm_event = false, hotplug_event = false;
     memset(&buffer, 0, sizeof(buffer));
-    size_t srclen = strlen(buffer);
+    size_t srclen = buffer_size - 1;
     ret = read(hotplug_fd_.get(), &buffer, srclen);
-    buffer[srclen] = '\0';
-    if (ret == 0) {
+    if (ret <= 0) {
+      if (ret < 0)
+        ETRACE("Failed to read uevent. %s", PRINTERROR());
       return;
-    } else if (ret < 0) {
-      ETRACE("Failed to read uevent. %s", PRINTERROR());
-      return;
+    } else {
+      buffer[ret] = '\0';
     }
 
     for (int32_t i = 0; i < ret;) {


### PR DESCRIPTION
As the buffer is statically allocated, store the size in a variable.
Also, doing a strlen after memset would always return 0. This also fixes the
over heating issue addressed in the below jira.

Jira: IAHWC-69
Tests: Board should boot to home screen and in idle state temperature should
be between 40 to 50 degrees. check /sys/class/thermal/thermal_zone0/temp for
cpu temperature

Signed-off-by: Harish Krupo <harish.krupo.kps@intel.com>