### PR TITLE
Do not build PIC code for Android

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -75,10 +75,10 @@ LOCAL_CPPFLAGS += \
 	-DHWC2_INCLUDE_STRINGIFICATION \
 	-DUSE_ANDROID_SYNC \
 	-DUSE_ANDROID_SHIM \
-	-fPIC -O2 \
+	-O2 \
 	-D_FORTIFY_SOURCE=2 \
 	-fstack-protector-strong \
-	-fPIE -Wformat -Wformat-security
+	-Wformat -Wformat-security
 
 ifeq ($(strip $(BOARD_DISABLE_NATIVE_COLOR_MODES)),true)
 LOCAL_CPPFLAGS += -DDISABLE_NATIVE_COLOR_MODES

--- a/os/android/platformdefines.h
+++ b/os/android/platformdefines.h
@@ -17,6 +17,9 @@
 #ifndef OS_ANDROID_PLATFORMDEFINES_H_
 #define OS_ANDROID_PLATFORMDEFINES_H_
 
+#ifndef LOG_TAG
+#define LOG_TAG "iahwcomposer"
+#endif
 #include <cutils/log.h>
 #include <hardware/hardware.h>
 #include <hardware/hwcomposer.h>


### PR DESCRIPTION
The recent Android platform doesn't allow to have text relocations.
https://android.googlesource.com/platform/bionic/+/master/android-changes-for-ndk-developers.md#Text-Relocations-Enforced-for-API-level-23
To comply the rule, removed "-fPIC, -fPIE" options.
Also added LOG_TAG definition to show module name on Android logcat.

Bug: 37487613
Change-Id: Id5278b2e131d2a635546595ef38f154c238f7c9d