### PR TITLE
Add null pointer checks

### DIFF
--- a/common/display/displayqueue.cpp
+++ b/common/display/displayqueue.cpp
@@ -111,6 +111,9 @@ bool DisplayQueue::Initialize(uint32_t width, uint32_t height, uint32_t pipe,
   drmModePropertyPtr broadcastrgb_props =
       drmModeGetProperty(gpu_fd_, broadcastrgb_id_);
 
+  if (!broadcastrgb_props)
+    return true;
+
   if (!(broadcastrgb_props->flags & DRM_MODE_PROP_ENUM))
     return false;
 


### PR DESCRIPTION
Broadcast RGB properties are not defined for DSI display panel

Change-Id: I21f1c9adf4780ad6bd45b7dc85a82edcd9414010
Signed-off-by: Ragha Khandenahally <Ragha.Khandenahally@intel.com>