### PR TITLE
Hot plug event handler modified to reduce cycles consumed

### DIFF
--- a/common/core/gpudevice.cpp
+++ b/common/core/gpudevice.cpp
@@ -164,15 +164,15 @@ bool GpuDevice::DisplayManager::Init(uint32_t fd) {
 
 void GpuDevice::DisplayManager::HotPlugEventHandler() {
   CTRACE();
-  uint32_t buffer_size = 1024;
-  char buffer[buffer_size];
+  int fd = hotplug_fd_.get();
+  char buffer[DRM_HOTPLUG_EVENT_SIZE];
   int ret;
 
+  memset(&buffer, 0, sizeof(buffer));
   while (true) {
     bool drm_event = false, hotplug_event = false;
-    memset(&buffer, 0, sizeof(buffer));
-    size_t srclen = buffer_size - 1;
-    ret = read(hotplug_fd_.get(), &buffer, srclen);
+    size_t srclen = DRM_HOTPLUG_EVENT_SIZE - 1;
+    ret = read(fd, &buffer, srclen);
     if (ret <= 0) {
       if (ret < 0)
         ETRACE("Failed to read uevent. %s", PRINTERROR());

--- a/public/gpudevice.h
+++ b/public/gpudevice.h
@@ -27,6 +27,8 @@ namespace hwcomposer {
 
 class NativeDisplay;
 
+#define DRM_HOTPLUG_EVENT_SIZE 256
+
 class DisplayHotPlugEventCallback {
  public:
   virtual ~DisplayHotPlugEventCallback() {


### PR DESCRIPTION
HotPlugEventHandler is in runtime path for all usecases and hence matters for performance.

Moved memset and fd query out of the loop
Reduced buffer size to 256
Added sleep to avoid busy looping

Test:Device boots to home screen
     Perf bench marks with AIA

Result: Improves performance.

Signed-off-by: Aravindan M <aravindan.muthukumar@intel.com>
Signed-off-by: Yogesh Marathe <yogesh.marathe@intel.com>