### PR TITLE
Avoiding busy loop in HotPlugEventHandler

### DIFF
--- a/common/core/gpudevice.cpp
+++ b/common/core/gpudevice.cpp
@@ -202,6 +202,11 @@ void GpuDevice::DisplayManager::HotPlugEventHandler() {
       UpdateDisplayState();
     }
   }
+  /* Adding sleep to avoid busy loop. The busy loop returns only
+   * if read() completes / fails. Race conditions can cause this
+   * busy loop hog the system. This 1 ms sleep can avoid that.
+   */
+  usleep(1000);
 }
 
 void GpuDevice::DisplayManager::HandleWait() {


### PR DESCRIPTION
The busy loop in HotPlugEventHandler can cause issues in race conditions
as it doesn't have any blocking system call or sleep. This patch avoids that.

Test: Android perf benches and hotplug on the device.

Signed-off-by: Yogesh Marathe <yogesh.marathe@intel.com>
Signed-off-by: Aravindan M <aravindan.muthukumar@intel.com>