### PR TITLE
Support DRM_FORMAT_YVU420_ANDROID enum

### DIFF
--- a/common/core/overlaybuffer.cpp
+++ b/common/core/overlaybuffer.cpp
@@ -26,6 +26,11 @@
 
 #include "hwctrace.h"
 
+#ifdef USE_MINIGBM
+// minigbm specific DRM_FORMAT_YVU420_ANDROID enum
+#define DRM_FORMAT_YVU420_ANDROID              fourcc_code('9', '9', '9', '7')
+#endif
+
 namespace hwcomposer {
 
 OverlayBuffer::~OverlayBuffer() {
@@ -81,6 +86,11 @@ GpuImage OverlayBuffer::ImportImage(GpuDisplay egl_display) {
           egl_display, EGL_NO_CONTEXT, EGL_LINUX_DMA_BUF_EXT,
           static_cast<EGLClientBuffer>(nullptr), attr_list_nv12);
     } else {
+#ifdef USE_MINIGBM
+      // switch minigbm specific enum to a standard one
+      if (format_ == DRM_FORMAT_YVU420_ANDROID)
+        format_ = DRM_FORMAT_YVU420;
+#endif
       const EGLint attr_list_yv12[] = {
           EGL_WIDTH,                     static_cast<EGLint>(width_),
           EGL_HEIGHT,                    static_cast<EGLint>(height_),
@@ -162,6 +172,9 @@ void OverlayBuffer::SetRecommendedFormat(uint32_t format) {
     case DRM_FORMAT_UYVY:
     case DRM_FORMAT_NV12:
     case DRM_FORMAT_YUV420:
+#ifdef USE_MINIGBM
+    case DRM_FORMAT_YVU420_ANDROID:
+#endif
       is_yuv_ = true;
       break;
     default:


### PR DESCRIPTION
Support minigbm specific format by switching it to standard
one when importing image.

Jira: None.
Test: Working video playback after minigbm rebase.

Signed-off-by: Tapani Pälli <tapani.palli@intel.com>