### PR TITLE
Add surface damage support

### DIFF
--- a/common/core/hwclayer.cpp
+++ b/common/core/hwclayer.cpp
@@ -42,4 +42,8 @@ void HwcLayer::SetDisplayFrame(const HwcRect<int>& display_frame) {
   display_frame_ = display_frame;
 }
 
+void HwcLayer::SetSurfaceDamage(const HwcRegion& surface_damage) {
+  surface_damage_ = surface_damage;
+}
+
 }  // namespace hwcomposer

--- a/common/core/overlaylayer.cpp
+++ b/common/core/overlaylayer.cpp
@@ -112,6 +112,29 @@ void OverlayLayer::ValidatePreviousFrameState(const OverlayLayer& rhs) {
   }
 }
 
+void OverlayLayer::SetSurfaceDamage(const HwcRegion& surface_damage,
+                                    const OverlayLayer& rhs) {
+  // check the surafce damage if its 0 for all layers then skip validate
+  // and commit
+  if (surface_damage.kNumRects == 1) {
+    const HwcRect<int>* rect = surface_damage.kRects;
+    if ((rect->top == 0) && (rect->bottom == 0) && (rect->left == 0) &&
+        (rect->right == 0)) {
+      layer_attributes_changed_ = false;
+
+      const HwcRect<int>& previous = rhs.GetDisplayFrame();
+      if ((previous.left == display_frame_.left) &&
+          (previous.top == display_frame_.top)) {
+        layer_pos_changed_ = false;
+      }
+
+      return;
+    }
+  }
+
+  ValidatePreviousFrameState(rhs);
+}
+
 void OverlayLayer::Dump() {
   DUMPTRACE("OverlayLayer Information Starts. -------------");
   switch (blending_) {

--- a/common/core/overlaylayer.h
+++ b/common/core/overlaylayer.h
@@ -131,6 +131,10 @@ struct OverlayLayer {
     return layer_attributes_changed_;
   }
 
+  // Damage region associated with this layer from
+  // previous frame.
+  void SetSurfaceDamage(const HwcRegion& surface_damage,
+                        const OverlayLayer& rhs);
   void Dump();
 
  private:

--- a/os/android/drmhwctwo.cpp
+++ b/os/android/drmhwctwo.cpp
@@ -504,11 +504,16 @@ HWC2::Error DrmHwcTwo::HwcDisplay::SetActiveConfig(hwc2_config_t config) {
 HWC2::Error DrmHwcTwo::HwcDisplay::SetClientTarget(buffer_handle_t target,
                                                    int32_t acquire_fence,
                                                    int32_t dataspace,
-                                                   hwc_region_t /*damage*/) {
+                                                   hwc_region_t damage) {
   supported(__func__);
   client_layer_.set_buffer(target);
   client_layer_.set_acquire_fence(acquire_fence);
   client_layer_.SetLayerDataspace(dataspace);
+
+  ALOGE("SetLayerSurfaceDamage SetClientTarget %d \n", damage.numRects);
+  client_layer_.SetLayerSurfaceDamage(damage);
+  ALOGE("SetLayerSurfaceDamage ends SetClientTarget %d \n", damage.numRects);
+
   return HWC2::Error::None;
 }
 
@@ -692,9 +697,17 @@ HWC2::Error DrmHwcTwo::HwcLayer::SetLayerSourceCrop(hwc_frect_t crop) {
 }
 
 HWC2::Error DrmHwcTwo::HwcLayer::SetLayerSurfaceDamage(hwc_region_t damage) {
-  supported(__func__);
-  // TODO: We don't use surface damage, marking as unsupported
-  unsupported(__func__, damage);
+  std::vector<hwcomposer::HwcRect<int>> hwc_rects;
+  for (size_t rect = 0; rect < damage.numRects; ++rect) {
+    hwc_rects.push_back({damage.rects[rect].left, damage.rects[rect].top,
+                         damage.rects[rect].right, damage.rects[rect].bottom});
+  }
+
+  hwcomposer::HwcRegion hwc_region = {};
+  hwc_region.kNumRects = damage.numRects;
+  hwc_region.kRects = hwc_rects.data();
+
+  hwc_layer_.SetSurfaceDamage(hwc_region);
   return HWC2::Error::None;
 }
 

--- a/public/hwcdefs.h
+++ b/public/hwcdefs.h
@@ -26,6 +26,11 @@ namespace hwcomposer {
 template <typename T>
 using HwcRect = Rect<T>;
 
+struct HwcRegion {
+  uint32_t kNumRects = 0;
+  HwcRect<int> const* kRects;
+};
+
 enum class HWCBlending : int32_t {
   kBlendingNone = 0x0100,
   kBlendingPremult = 0x0105,

--- a/public/hwclayer.h
+++ b/public/hwclayer.h
@@ -62,6 +62,11 @@ struct HwcLayer {
     return display_frame_;
   }
 
+  void SetSurfaceDamage(const HwcRegion& surface_damage);
+  const HwcRegion& GetSurfaceDamage() const {
+    return surface_damage_;
+  }
+
  private:
   uint32_t transform_ = 0;
   uint8_t alpha_ = 0xff;
@@ -69,6 +74,7 @@ struct HwcLayer {
   HwcRect<int> display_frame_;
   HWCBlending blending_ = HWCBlending::kBlendingNone;
   HWCNativeHandle sf_handle_ = 0;
+  HwcRegion surface_damage_;
 };
 
 }  // namespace hwcomposer


### PR DESCRIPTION
Added the basic support to avoid the complete validate if the
given layers are same as previous one.

Jira: IAHWC-51
Test: No regressions with Linux app and on Android

Signed-off-by: Pallavi G <pallavi.g@intel.com>
Signed-off-by: Kalyan Kondapally <kalyan.kondapally@intel.com>