### PR TITLE
Make HWC library as a shared library

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -52,7 +52,7 @@ libhwcomposer_la_SOURCES += $(gl_SOURCES)
 AM_CPPFLAGS += -DUSE_GL
 endif
 libhwcomposer_ladir = $(libdir)
-libhwcomposer_la_LDFLAGS = -version-number 0:0:1 -no-undefined -static
+libhwcomposer_la_LDFLAGS = -version-number 0:0:1 -no-undefined -shared
 
 libhwcincdir = $(includedir)/libhwc
 libhwcinc_HEADERS =	\

--- a/Makefile.am
+++ b/Makefile.am
@@ -54,6 +54,19 @@ endif
 libhwcomposer_ladir = $(libdir)
 libhwcomposer_la_LDFLAGS = -version-number 0:0:1 -no-undefined -static
 
+libhwcincdir = $(includedir)/libhwc
+libhwcinc_HEADERS =	\
+	$(top_srcdir)/public/gpudevice.h	\
+	$(top_srcdir)/public/hwcbuffer.h	\
+	$(top_srcdir)/public/hwcdefs.h	\
+	$(top_srcdir)/public/hwclayer.h	\
+	$(top_srcdir)/public/hwcrect.h	\
+	$(top_srcdir)/public/nativebufferhandler.h	\
+	$(top_srcdir)/public/nativedisplay.h	\
+	$(top_srcdir)/public/nativefence.h	\
+	$(top_srcdir)/public/scopedfd.h	\
+	$(top_srcdir)/public/spinlock.h
+
 .PHONY: ChangeLog INSTALL
 
 INSTALL:

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -21,7 +21,10 @@
 #  SOFTWARE.
 #
 
-bin_PROGRAMS = testlayers colorcorrection_autotest
+bin_PROGRAMS = testlayers
+if !ENABLE_GBM
+bin_PROGRAMS += colorcorrection_autotest
+endif
 
 testlayers_LDFLAGS = \
 	-no-undefined
@@ -62,7 +65,6 @@ if !ENABLE_GBM
 testlayers_SOURCES +=   \
     ./common/videolayerrenderer.cpp \
     ./common/imagelayerrenderer.cpp
-endif
 
 colorcorrection_autotest_LDFLAGS = \
         -no-undefined
@@ -81,3 +83,4 @@ colorcorrection_autotest_CFLAGS = \
 colorcorrection_autotest_SOURCES = \
      ./autotests/colorcorrection_autotest.cpp \
      ./common/igt.cpp
+endif


### PR DESCRIPTION
Install public headers and also fixes build errors when gbm is uses instead of minigbm