### PR TITLE
Fix error when initializing virtual display.

### DIFF
--- a/common/display/virtualdisplay.cpp
+++ b/common/display/virtualdisplay.cpp
@@ -56,6 +56,10 @@ bool VirtualDisplay::GetActiveConfig(uint32_t *config) {
   return true;
 }
 
+bool VirtualDisplay::SetActiveConfig(uint32_t /*config*/) {
+  return true;
+}
+
 bool VirtualDisplay::Present(std::vector<HwcLayer *> &source_layers,
                              int32_t *retire_fence) {
   CTRACE();

--- a/common/display/virtualdisplay.h
+++ b/common/display/virtualdisplay.h
@@ -37,6 +37,8 @@ class VirtualDisplay : public Headless {
 
   bool GetActiveConfig(uint32_t *config) override;
 
+  bool SetActiveConfig(uint32_t config) override;
+
   bool Present(std::vector<HwcLayer *> &source_layers,
                int32_t *retire_fence) override;
 


### PR DESCRIPTION
SurfaceFlinger expects SetActiveConfig to pass but we returned
false here.

Jira: None.
Test: Dont see any HWC failures when initializing Virtual Display.

Signed-off-by: Kalyan Kondapally <kalyan.kondapally@intel.com>