### PR TITLE
Enable Systrace for Android platform

### DIFF
--- a/common/core/overlaybuffermanager.cpp
+++ b/common/core/overlaybuffermanager.cpp
@@ -128,6 +128,7 @@ void OverlayBufferManager::UnRegisterBuffers(
 
 void OverlayBufferManager::UnRegisterLayerBuffers(
     std::vector<OverlayLayer>& layers) {
+  CTRACE();
   for (OverlayLayer& layer : layers) {
     const OverlayBuffer* const buffer = layer.GetBuffer();
     if (!buffer)

--- a/common/utils/hwctrace.h
+++ b/common/utils/hwctrace.h
@@ -63,7 +63,7 @@ class TraceFunc {
 };
 #define CTRACE() TraceFunc hwctrace(__func__);
 #else
-#define CTRACE() ((void)0)
+#define CTRACE()  STRACE()
 #endif
 
 // Arguments tracing

--- a/common/utils/hwcutils.cpp
+++ b/common/utils/hwcutils.cpp
@@ -23,6 +23,7 @@
 namespace hwcomposer {
 
 void HWCPoll(int fd, int timeout) {
+  CTRACE();
   struct pollfd fds[1];
   fds[0].fd = fd;
   fds[0].events = POLLIN;

--- a/os/android/platformdefines.h
+++ b/os/android/platformdefines.h
@@ -20,6 +20,12 @@
 #ifndef LOG_TAG
 #define LOG_TAG "iahwcomposer"
 #endif
+
+#ifndef ATRACE_TAG
+#define ATRACE_TAG ATRACE_TAG_GRAPHICS
+#endif
+
+#include <utils/Trace.h>
 #include <cutils/log.h>
 #include <hardware/hardware.h>
 #include <hardware/hwcomposer.h>
@@ -45,7 +51,7 @@ typedef struct gralloc_handle* HWCNativeHandle;
 #define ITRACE(fmt, ...) ALOGI(fmt, ##__VA_ARGS__)
 #define WTRACE(fmt, ...) ALOGW("%s: " fmt, __func__, ##__VA_ARGS__)
 #define ETRACE(fmt, ...) ALOGE("%s: " fmt, __func__, ##__VA_ARGS__)
-
+#define STRACE() ATRACE_CALL()
 // _cplusplus
 #ifdef _cplusplus
 }

--- a/os/linux/platformdefines.h
+++ b/os/linux/platformdefines.h
@@ -47,7 +47,7 @@ extern "C" {
 #define ITRACE(fmt, ...) fprintf(stderr, "\n" fmt, ##__VA_ARGS__)
 #define WTRACE(fmt, ...) fprintf(stderr, "%s: \n" fmt, __func__, ##__VA_ARGS__)
 #define ETRACE(fmt, ...) fprintf(stderr, "%s: \n" fmt, __func__, ##__VA_ARGS__)
-
+#define STRACE() ((void)0)
 // _cplusplus
 #ifdef _cplusplus
 }


### PR DESCRIPTION
For Android platform, we can make CTRACE output the
atrace logs which can be shown in systrace.

Jira: None.
Test: No impact on Linux and Android.

Signed-off-by: Zhongmin Wu <zhongmin.wu@intel.com>