### PR TITLE
Add Travis CI support with packaged depends.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,34 @@
+language: c++
+sudo: required
+dist: trusty
+install:
+- sudo apt-get update
+- sudo apt-get install automake
+- sudo apt-get install autoconf
+- sudo apt-get install libtool
+- sudo apt-get install xutils-dev
+- sudo apt-get install libpciaccess-dev
+- sudo apt-get install python-mako
+- sudo dpkg -s python-mako
+- sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
+- sudo apt-get update
+- sudo apt-get install gcc-4.9
+- sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-4.9 50
+- sudo apt-get install g++-4.9
+- sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-4.9 50
+script:
+- export HWC_BUILD_DIR=/tmp/
+- export WLD=/tmp/hwc-install
+- export LD_LIBRARY_PATH=$WLD/lib
+- export PKG_CONFIG_PATH=$WLD/lib/pkgconfig/:$WLD/share/pkgconfig
+- export PATH=$WLD/bin:$PATH
+- export ACLOCAL_PATH=$WLD/share/aclocal
+- export ACLOCAL="aclocal -I $ACLOCAL_PATH"
+- export DRV_I915=1
+- tar -xvf travisci/resources/hwc-install.tar.bz2 -C $HWC_BUILD_DIR
+- mkdir -p $WLD/share/aclocal
+- ./autogen.sh --prefix=$WLD
+- make -j5
+branches:
+  only:
+  - master

--- a/travisci/travisci.md
+++ b/travisci/travisci.md
@@ -1,0 +1,21 @@
+## Debug Travis CI with Docker
+
+Host PC: Ubuntu 16.04 LTS with "su root"
+
+Reference: https://docs.travis-ci.com/user/common-build-problems/#Running-a-Container-Based-Docker-Image-Locally
+
+* Install Docker: apt-get install docker
+* Download Travis CI Docker image(refer to https://hub.docker.com/u/travisci/): docker pull travisci/ci-garnet:packer-1490989530
+* Start Docket service: service docker start
+* List existing images: docker images
+* Don't use this vritual net interface as we only need use --net=host: ifconfig docker0 down
+* Run Travis CI image in Docker: docker run --name travis-debug-001 --rm -v /mnt:/mnt/  --net=host -dit travisci/ci-garnet:packer-1490989530 /sbin/init
+* Switch to shell: docker exec -it travis-debug-001 bash -l
+* Setup network, e.g. proxy....to install dependance packages
+* Save changed image to new name: docker commit travis-debug-001 travis-debug-002
+
+## Commits of headers & libs
+* linux: https://github.com/android-ia/device-androidia-kernel.git "master" branch 9d2ec87a7f431fd699dc4b52c02fd421d961329d
+* libdrm: https://github.com/android-ia/external-libdrm.git "master" branch 82a4b6756572a9d708f174708615bddb2f472275
+* mesa: https://github.com/android-ia/external-mesa.git "master" branch 98b57dd99d603072da4e3dddf062de71303d4f84
+* mingbm: https://github.com/01org/minigbm.git "master" barnch deb93aca440ab75828c847cb3cec97a1315a69e2


### PR DESCRIPTION
Only build HWC and use Travis docker to build and collect headers
and libs, then Travis will install the headers and libs to CI system,
and do HWC config and build. travisci/travisci.md also hosts the steps
about how to build and collect headers and libs.

Jira: None.
Tests: Enable Travis CI for the branch and check if can process build
       for new commmits.

Signed-off-by: Fan Yugang <yugang.fan@intel.com>