### PR TITLE
fix compilation error when BOARD_USES_GRALLOC1 is set

### DIFF
--- a/os/android/gralloc1bufferhandler.cpp
+++ b/os/android/gralloc1bufferhandler.cpp
@@ -77,7 +77,7 @@ bool Gralloc1BufferHandler::Init() {
   return true;
 }
 
-bool Gralloc1BufferHandler::CreateBuffer(uint32_t w, uint32_t h, int /*format*/,
+bool Gralloc1BufferHandler::CreateBuffer(uint32_t w, uint32_t h, int format,
                                          HWCNativeHandle *handle) {
   return CreateGraphicsBuffer(w, h, format, handle);
 }


### PR DESCRIPTION
Jira: None.
Test: Code compiles without errors on Android when
      BOARD_USES_GRALLOC1 is set

Signed-off-by: Tapani Pälli <tapani.palli@intel.com>