### PR TITLE
Change definition place to fix assignment issue

### DIFF
--- a/tests/apps/jsonlayerstest.cpp
+++ b/tests/apps/jsonlayerstest.cpp
@@ -479,7 +479,7 @@ static void init_frames(int32_t width, int32_t height) {
 
     for (size_t j = 0; j < LAYER_PARAM_SIZE; ++j) {
       if (!display_mode)
-        LAYER_PARAMETER layer_parameter = test_parameters.layers_parameters[j];
+        layer_parameter = test_parameters.layers_parameters[j];
 
       LayerRenderer *renderer = NULL;
       hwcomposer::HwcLayer *hwc_layer = NULL;


### PR DESCRIPTION
Move layer_parameter definition to outside of for to avoid the
assignment issue which will cause the render init failure.

Jira: None.
Test: Test app works normally without render init issue.

Signed-off-by: Fan Yugang <yugang.fan@intel.com>