### PR TITLE
Fix for cursor source crop position

### DIFF
--- a/common/display/displayplane.cpp
+++ b/common/display/displayplane.cpp
@@ -160,30 +160,32 @@ bool DisplayPlane::UpdateProperties(drmModeAtomicReqPtr property_set,
                                       display_frame.left) < 0;
   success |= drmModeAtomicAddProperty(property_set, id_, crtc_y_prop_.id,
                                       display_frame.top) < 0;
+
   if (type_ == DRM_PLANE_TYPE_CURSOR) {
     success |= drmModeAtomicAddProperty(property_set, id_, crtc_w_prop_.id,
                                         buffer->GetWidth()) < 0;
     success |= drmModeAtomicAddProperty(property_set, id_, crtc_h_prop_.id,
                                         buffer->GetHeight()) < 0;
-  } else {
-    success |= drmModeAtomicAddProperty(property_set, id_, crtc_w_prop_.id,
-                                        layer->GetDisplayFrameWidth()) < 0;
-    success |= drmModeAtomicAddProperty(property_set, id_, crtc_h_prop_.id,
-                                        layer->GetDisplayFrameHeight()) < 0;
-  }
+    success |=
+        drmModeAtomicAddProperty(property_set, id_, src_x_prop_.id, 0) < 0;
+    success |=
+        drmModeAtomicAddProperty(property_set, id_, src_y_prop_.id, 0) < 0;
 
-  success |=
-      drmModeAtomicAddProperty(property_set, id_, src_x_prop_.id,
-                               static_cast<int>(source_crop.left) << 16) < 0;
-  success |=
-      drmModeAtomicAddProperty(property_set, id_, src_y_prop_.id,
-                               static_cast<int>(source_crop.top) << 16) < 0;
-  if (type_ == DRM_PLANE_TYPE_CURSOR) {
     success |= drmModeAtomicAddProperty(property_set, id_, src_w_prop_.id,
                                         buffer->GetWidth() << 16) < 0;
     success |= drmModeAtomicAddProperty(property_set, id_, src_h_prop_.id,
                                         buffer->GetHeight() << 16) < 0;
   } else {
+    success |= drmModeAtomicAddProperty(property_set, id_, crtc_w_prop_.id,
+                                        layer->GetDisplayFrameWidth()) < 0;
+    success |= drmModeAtomicAddProperty(property_set, id_, crtc_h_prop_.id,
+                                        layer->GetDisplayFrameHeight()) < 0;
+    success |=
+        drmModeAtomicAddProperty(property_set, id_, src_x_prop_.id,
+                                 static_cast<int>(source_crop.left) << 16) < 0;
+    success |=
+        drmModeAtomicAddProperty(property_set, id_, src_y_prop_.id,
+                                 static_cast<int>(source_crop.top) << 16) < 0;
     success |= drmModeAtomicAddProperty(property_set, id_, src_w_prop_.id,
                                         layer->GetSourceCropWidth() << 16) < 0;
     success |= drmModeAtomicAddProperty(property_set, id_, src_h_prop_.id,


### PR DESCRIPTION
Sometimes the Android framework sets the source crop position coordinates x and y to some non zero value.
Due to that the drm kernel plane check is failing and the cursor is falling back to the gpu path.

Irrespective of the x and y value make it to zero, anyway we allocate the cursor buffer
size bigger then the required size.

Jira : IAHWC-73
Test : Tested on Android, no cursor layer falling back to gpu

Change-Id: I953e5f1e39e9474e6920fd625346e2f7d47671f5
Signed-off-by: Pallavi G <pallavi.g@intel.com>