### PR TITLE
REVERT [PARTIAL] : Disable invoking of hwc.info service

### DIFF
--- a/os/android/drmhwctwo.cpp
+++ b/os/android/drmhwctwo.cpp
@@ -95,7 +95,9 @@ HWC2::Error DrmHwcTwo::Init() {
   displays_.at(HWC_DISPLAY_PRIMARY).Init(disable_explicit_sync_);
 
   // Start the hwc service
-  hwcService_.Start(*this);
+  // FIXME: On Android, with userdebug on Joule this is causing
+  //        to hang in a loop while cold boot before going to home screen
+  // hwcService_.Start(*this);
 
   return HWC2::Error::None;
 }


### PR DESCRIPTION
In User debug builds, while Joule board boots via ColdBoot or ALT+CTRL+DEL,
it loops in for a while between Android TEXT and Android Animation before
reaching the home screen.
This patch disables invoking of hwc.info service which fixes the issue.

Signed-off-by: Kishore Kadiyala <kishore.kadiyala@intel.com>